### PR TITLE
Add CRPSLoss for generative models and extend DeepESDpr with new functionalities

### DIFF
--- a/deep4downscaling/deep/loss.py
+++ b/deep4downscaling/deep/loss.py
@@ -496,3 +496,38 @@ class Asym(nn.Module):
         return loss
     
 # CRPS Loss Function
+class CRPSLoss(nn.Module):
+
+    """
+    Continuous Ranked Probabiliy Score (CRPS). It is possible to compute
+    this metric over a target dataset with nans.
+
+    Parameters
+    ----------
+    ignore_nans : bool
+        Whether to allow the loss function to ignore nans in the
+        target domain.
+
+    target : torch.Tensor
+        Target/ground-truth data
+
+    output : torch.Tensor
+        Predicted data (model's output)
+    """
+
+    def __init__(self, ignore_nans: bool) -> None:
+        super(CRPSLoss, self).__init__()
+        self.ignore_nans = ignore_nans
+
+    def forward(self, target: torch.Tensor, output: torch.Tensor, output2: torch.Tensor, beta: int) -> torch.Tensor: ######NUEVO
+
+        if self.ignore_nans:
+            nans_idx = torch.isnan(target)
+            output = output[~nans_idx]
+            output2 = output2[~nans_idx]
+            target = target[~nans_idx]
+        s1 = torch.mean(torch.abs(target - output) ** beta)
+        s2 = torch.mean(torch.abs(target - output2) ** beta)
+        loss = ((s1+s2)/2) - 1/2 * torch.mean(torch.abs(output - output2) ** beta)  
+
+        return loss

--- a/deep4downscaling/deep/loss.py
+++ b/deep4downscaling/deep/loss.py
@@ -498,8 +498,9 @@ class Asym(nn.Module):
 class CRPSLoss(nn.Module):
 
     """
-    Continuous Ranked Probability Score (CRPS). It is possible to compute
-    this metric over a target dataset with nans.
+    Fair Continuous Ranked Probability Score (CRPS). It is possible to compute
+    this metric over a target dataset with nans. This is the same as the CRPS,
+    but the second term is divided by 2*M*(M-1) instead of M**2.
 
     Parameters
     ----------
@@ -543,12 +544,14 @@ class CRPSLoss(nn.Module):
         first_term = first_term / M
 
         # Difference between all pairs of predictions
-        # We divide by M**2 and not by 2*M**2 as we do not repeat the same pairs
-        second_term = 0.0
-        for i in range(M):
-            for j in range(i + 1, M): # We do not repeat the same pairs
-                second_term += torch.abs(output[i] - output[j]) ** beta
-        second_term = second_term / (M ** 2)
+        if M > 1:
+            second_term = 0.0
+            for i in range(M):
+                for j in range(M):
+                    second_term += torch.abs(output[i] - output[j]) ** beta
+            second_term = second_term / (2*M*(M-1)) # Fair CRPS
+        else: # Just return the first term
+            second_term = 0.0
 
         # Final loss
         loss = torch.mean(first_term - second_term)

--- a/deep4downscaling/deep/loss.py
+++ b/deep4downscaling/deep/loss.py
@@ -541,7 +541,6 @@ class CRPSLoss(nn.Module):
         for i in range(M):
             first_term += torch.abs(target - output[i]) ** beta
         first_term = first_term / M
-        first_term = torch.mean(first_term)
 
         # Difference between all pairs of predictions
         # We divide by M**2 and not by 2*M**2 as we do not repeat the same pairs
@@ -550,9 +549,8 @@ class CRPSLoss(nn.Module):
             for j in range(i + 1, M): # We do not repeat the same pairs
                 second_term += torch.abs(output[i] - output[j]) ** beta
         second_term = second_term / (M ** 2)
-        second_term = torch.mean(second_term)
 
         # Final loss
-        loss = first_term - second_term
+        loss = torch.mean(first_term - second_term)
 
         return loss

--- a/deep4downscaling/deep/loss.py
+++ b/deep4downscaling/deep/loss.py
@@ -494,3 +494,5 @@ class Asym(nn.Module):
         loss = loss_mae + self.asym_weight * loss_asym
 
         return loss
+    
+# CRPS Loss Function

--- a/deep4downscaling/deep/loss.py
+++ b/deep4downscaling/deep/loss.py
@@ -495,11 +495,10 @@ class Asym(nn.Module):
 
         return loss
     
-# CRPS Loss Function
 class CRPSLoss(nn.Module):
 
     """
-    Continuous Ranked Probabiliy Score (CRPS). It is possible to compute
+    Continuous Ranked Probability Score (CRPS). It is possible to compute
     this metric over a target dataset with nans.
 
     Parameters
@@ -511,23 +510,49 @@ class CRPSLoss(nn.Module):
     target : torch.Tensor
         Target/ground-truth data
 
-    output : torch.Tensor
-        Predicted data (model's output)
+    output : list of torch.Tensor or torch.Tensor
+        List of predicted data (model's outputs) for ensemble predictions,
+        or a single tensor (which will be wrapped in a list automatically).
+        For proper CRPS computation, at least 2 ensemble members are required.
+
+    beta : int
+        Power parameter for the absolute differences in the CRPS computation.
     """
 
     def __init__(self, ignore_nans: bool) -> None:
         super(CRPSLoss, self).__init__()
         self.ignore_nans = ignore_nans
 
-    def forward(self, target: torch.Tensor, output: torch.Tensor, output2: torch.Tensor, beta: int) -> torch.Tensor: ######NUEVO
+    def forward(self, target: torch.Tensor, output, beta: int = 1) -> torch.Tensor:
 
+        if isinstance(output, torch.Tensor):
+            output = [output]
+        
         if self.ignore_nans:
             nans_idx = torch.isnan(target)
-            output = output[~nans_idx]
-            output2 = output2[~nans_idx]
             target = target[~nans_idx]
-        s1 = torch.mean(torch.abs(target - output) ** beta)
-        s2 = torch.mean(torch.abs(target - output2) ** beta)
-        loss = ((s1+s2)/2) - 1/2 * torch.mean(torch.abs(output - output2) ** beta)  
+            output = [out[~nans_idx] for out in output]
+
+        # Number of ensemble members
+        M = len(output)
+
+        # Error between target and each prediction
+        first_term = 0.0
+        for i in range(M):
+            first_term += torch.abs(target - output[i]) ** beta
+        first_term = first_term / M
+        first_term = torch.mean(first_term)
+
+        # Difference between all pairs of predictions
+        # We divide by M**2 and not by 2*M**2 as we do not repeat the same pairs
+        second_term = 0.0
+        for i in range(M):
+            for j in range(i + 1, M): # We do not repeat the same pairs
+                second_term += torch.abs(output[i] - output[j]) ** beta
+        second_term = second_term / (M ** 2)
+        second_term = torch.mean(second_term)
+
+        # Final loss
+        loss = first_term - second_term
 
         return loss

--- a/deep4downscaling/deep/models.py
+++ b/deep4downscaling/deep/models.py
@@ -240,15 +240,11 @@ class DeepESDpr(torch.nn.Module):
         If set to True, the output of the last dense layer is passed through a
         ReLU activation function. This does not apply when stochastic=True. By
         default is set to False.
-
-    num_channels_noise: int, opional
-        If greater than 0, the model will include the specified number of additional channels as input,
-        effectively making the model generative by injecting noise into the input.  
     """
 
     def __init__(self, x_shape: tuple, y_shape: tuple,
                  filters_last_conv: int, stochastic: bool,
-                 last_relu: bool=False, num_channels_noise: int = 0):
+                 last_relu: bool=False):
 
         super(DeepESDpr, self).__init__()
 
@@ -264,29 +260,18 @@ class DeepESDpr(torch.nn.Module):
         self.filters_last_conv = filters_last_conv
         self.stochastic = stochastic
         self.last_relu = last_relu
-        self.num_channels_noise = num_channels_noise
 
-        self.conv_1 = torch.nn.Conv2d(in_channels=self.x_shape[1] + num_channels_noise,
+        self.conv_1 = torch.nn.Conv2d(in_channels=self.x_shape[1],
                                       out_channels=50,
                                       kernel_size=3,
                                       padding=1)
-        
-        if self.num_channels_noise > 0:
-            in_channels = 50 + num_channels_noise - ceil(0.3 * self.num_channels_noise)
-        else:
-            in_channels = 50 
 
-        self.conv_2 = torch.nn.Conv2d(in_channels=in_channels,
+        self.conv_2 = torch.nn.Conv2d(in_channels=50,
                                       out_channels=25,
                                       kernel_size=3,
                                       padding=1)
-        
-        if self.num_channels_noise > 0:
-            in_channels = 25 + num_channels_noise - ceil(0.6 * self.num_channels_noise)
-        else:
-            in_channels = 25 
 
-        self.conv_3 = torch.nn.Conv2d(in_channels=in_channels,
+        self.conv_3 = torch.nn.Conv2d(in_channels=25,
                                       out_channels=self.filters_last_conv,
                                       kernel_size=3,
                                       padding=1)
@@ -311,26 +296,11 @@ class DeepESDpr(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
 
-        if self.num_channels_noise > 0:
-            x_noise = torch.randn((x.shape[0],
-                                   self.num_channels_noise, x.shape[2], x.shape[3])).to(x.device)
-            x = torch.cat((x, x_noise), 1)
-
         x = self.conv_1(x)
         x = torch.relu(x)
 
-        if self.num_channels_noise > 0:
-            x_noise = torch.randn((x.shape[0],
-                                    self.num_channels_noise - ceil(0.3 * self.num_channels_noise), x.shape[2], x.shape[3])).to(x.device)
-            x = torch.cat((x, x_noise), 1)
-
         x = self.conv_2(x)
         x = torch.relu(x)
-
-        if self.num_channels_noise > 0:
-            x_noise = torch.randn((x.shape[0],
-                                    self.num_channels_noise - ceil(0.6 * self.num_channels_noise), x.shape[2], x.shape[3])).to(x.device)
-            x = torch.cat((x, x_noise), 1)
 
         x = self.conv_3(x)
         x = torch.relu(x)
@@ -350,6 +320,129 @@ class DeepESDpr(torch.nn.Module):
             if self.last_relu: out = torch.relu(out)
 
         return out
+
+class NoisyDeepESD(torch.nn.Module):
+
+    """
+    Noisy variant of DeepESD model  that injects noise into the convolutional
+    layers to generate stochastic outputs.
+
+    The noise is injected at multiple stages:
+    - Before the first convolutional layer: num_channels_noise channels
+    - After the first convolutional layer: reduced by 30%
+    - After the second convolutional layer: reduced by 60%
+
+    Parameters
+    ----------
+    x_shape : tuple
+        Shape of the data used as predictor. This must have dimension 4
+        (time, channels/variables, lon, lat).
+
+    y_shape : tuple
+        Shape of the data used as predictand. This must have dimension 2
+        (time, gridpoint)
+
+    filters_last_conv : int
+        Number of filters/kernels of the last convolutional layer
+
+    num_channels_noise: int
+        Number of noise channels to inject into the input. Must be greater than 0.
+        The noise is progressively reduced through the network layers.
+
+    last_relu: bool, optional
+        If set to True, the output of the last dense layer is passed through a
+        ReLU activation function. By default is set to False.
+    """
+
+    def __init__(self, x_shape: tuple, y_shape: tuple,
+                 filters_last_conv: int, num_channels_noise: int,
+                 last_relu: bool=False,
+                 members_for_training: int=2):
+
+        super(NoisyDeepESD, self).__init__()
+
+        if (len(x_shape) != 4) or (len(y_shape) != 2):
+            error_msg =\
+            'X and Y data must have a dimension of length 4'
+            'and 2, correspondingly'
+
+            raise ValueError(error_msg)
+
+        if num_channels_noise <= 0:
+            raise ValueError("num_channels_noise must be greater than 0 for NoisyDeepESD")
+
+        self.x_shape = x_shape
+        self.y_shape = y_shape
+        self.filters_last_conv = filters_last_conv
+        self.num_channels_noise = num_channels_noise
+        self.last_relu = last_relu
+        self.members_for_training = members_for_training
+
+        # First convolutional layer: input channels + noise channels
+        self.conv_1 = torch.nn.Conv2d(in_channels=self.x_shape[1] + num_channels_noise,
+                                      out_channels=50,
+                                      kernel_size=3,
+                                      padding=1)
+        
+        # Second convolutional layer: previous output + reduced noise (70% of original)
+        self.num_noise_channels_2 = num_channels_noise - ceil(0.3 * num_channels_noise)
+        self.conv_2 = torch.nn.Conv2d(in_channels=50 + self.num_noise_channels_2,
+                                      out_channels=25,
+                                      kernel_size=3,
+                                      padding=1)
+        
+        # Third convolutional layer: previous output + further reduced noise (40% of original)
+        self.num_noise_channels_3 = num_channels_noise - ceil(0.6 * num_channels_noise)
+        self.conv_3 = torch.nn.Conv2d(in_channels=25 + self.num_noise_channels_3,
+                                      out_channels=self.filters_last_conv,
+                                      kernel_size=3,
+                                      padding=1)
+
+        self.out = torch.nn.Linear(in_features=\
+                                   self.x_shape[2] * self.x_shape[3] * self.filters_last_conv,
+                                   out_features=self.y_shape[1])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+
+        if self.training:
+            members_to_iterate = self.members_for_training
+        else:
+            members_to_iterate = 1
+
+        out_members = []
+        for i in range(members_to_iterate):
+            noise_1 = torch.randn(x.shape[0], self.num_channels_noise, 
+                                  x.shape[2], x.shape[3], device=x.device)
+            x_feature = torch.cat((x, noise_1), dim=1)
+
+            x_feature = self.conv_1(x_feature)
+            x_feature = torch.relu(x_feature)
+
+            noise_2 = torch.randn(x_feature.shape[0], self.num_noise_channels_2, 
+                                  x_feature.shape[2], x_feature.shape[3], device=x.device)
+            x_feature = torch.cat((x_feature, noise_2), dim=1)
+
+            x_feature = self.conv_2(x_feature)
+            x_feature = torch.relu(x_feature)
+
+            noise_3 = torch.randn(x_feature.shape[0], self.num_noise_channels_3, 
+                                  x_feature.shape[2], x_feature.shape[3], device=x.device)
+            x_feature = torch.cat((x_feature, noise_3), dim=1)
+
+            x_feature = self.conv_3(x_feature)
+            x_feature = torch.relu(x_feature)
+
+            x_feature = torch.flatten(x_feature, start_dim=1)
+
+            out_member = self.out(x_feature)
+            if self.last_relu: 
+                out_member = torch.relu(out_member)
+            out_members.append(out_member)
+        
+        if self.training:
+            return out_members
+        else:
+            return out_members[0]
 
 class UnitConv(nn.Module):
     

--- a/deep4downscaling/deep/models.py
+++ b/deep4downscaling/deep/models.py
@@ -13,7 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.init as init
 import numpy as np
-
+from math import ceil
 
 class DeepESD_Discriminator(torch.nn.Module):
     """
@@ -240,11 +240,15 @@ class DeepESDpr(torch.nn.Module):
         If set to True, the output of the last dense layer is passed through a
         ReLU activation function. This does not apply when stochastic=True. By
         default is set to False.
+
+    num_channels_noise: int, opional
+        If greater than 0, the model will include the specified number of additional channels as input,
+        effectively making the model generative by injecting noise into the input.  
     """
 
     def __init__(self, x_shape: tuple, y_shape: tuple,
                  filters_last_conv: int, stochastic: bool,
-                 last_relu: bool=False):
+                 last_relu: bool=False, num_channels_noise: int = 0):
 
         super(DeepESDpr, self).__init__()
 
@@ -260,18 +264,29 @@ class DeepESDpr(torch.nn.Module):
         self.filters_last_conv = filters_last_conv
         self.stochastic = stochastic
         self.last_relu = last_relu
+        self.num_channels_noise = num_channels_noise
 
-        self.conv_1 = torch.nn.Conv2d(in_channels=self.x_shape[1],
+        self.conv_1 = torch.nn.Conv2d(in_channels=self.x_shape[1] + num_channels_noise,
                                       out_channels=50,
                                       kernel_size=3,
                                       padding=1)
+        
+        if self.num_channels_noise > 0:
+            in_channels = 50 + num_channels_noise - ceil(0.3 * self.num_channels_noise)
+        else:
+            in_channels = 50 
 
-        self.conv_2 = torch.nn.Conv2d(in_channels=50,
+        self.conv_2 = torch.nn.Conv2d(in_channels=in_channels,
                                       out_channels=25,
                                       kernel_size=3,
                                       padding=1)
+        
+        if self.num_channels_noise > 0:
+            in_channels = 25 + num_channels_noise - ceil(0.6 * self.num_channels_noise)
+        else:
+            in_channels = 25 
 
-        self.conv_3 = torch.nn.Conv2d(in_channels=25,
+        self.conv_3 = torch.nn.Conv2d(in_channels=in_channels,
                                       out_channels=self.filters_last_conv,
                                       kernel_size=3,
                                       padding=1)
@@ -296,11 +311,26 @@ class DeepESDpr(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
 
+        if self.num_channels_noise > 0:
+            x_noise = torch.randn((x.shape[0],
+                                   self.num_channels_noise, x.shape[2], x.shape[3])).to(x.device)
+            x = torch.cat((x, x_noise), 1)
+
         x = self.conv_1(x)
         x = torch.relu(x)
 
+        if self.num_channels_noise > 0:
+            x_noise = torch.randn((x.shape[0],
+                                    self.num_channels_noise - ceil(0.3 * self.num_channels_noise), x.shape[2], x.shape[3])).to(x.device)
+            x = torch.cat((x, x_noise), 1)
+
         x = self.conv_2(x)
         x = torch.relu(x)
+
+        if self.num_channels_noise > 0:
+            x_noise = torch.randn((x.shape[0],
+                                    self.num_channels_noise - ceil(0.6 * self.num_channels_noise), x.shape[2], x.shape[3])).to(x.device)
+            x = torch.cat((x, x_noise), 1)
 
         x = self.conv_3(x)
         x = torch.relu(x)


### PR DESCRIPTION
Add `CRPSLoss` loss function to use with generative models. Also this PR updates `DeepESDpr` to support generative behavior through a new optional parameter, `num_noise_channels.`