### PR TITLE
Add versioned model saving, configurable spread normalisation, and spectral loss component figure to tracker

### DIFF
--- a/deep4downscaling/deep/loss/crps.py
+++ b/deep4downscaling/deep/loss/crps.py
@@ -28,6 +28,11 @@ class CRPSLoss(nn.Module):
     beta : int
         Power parameter for the absolute differences in the CRPS computation.
 
+    spread_norm : float, optional
+        Divisor for the spread term (second term). When None (default), the
+        fair-CRPS divisor 2*M*(M-1) is used. Pass a custom value (e.g. 2)
+        to override it.
+
     target : torch.Tensor
         Target/ground-truth data
 
@@ -37,16 +42,18 @@ class CRPSLoss(nn.Module):
         For proper CRPS computation, at least 2 ensemble members are required.
     """
 
-    def __init__(self, ignore_nans: bool, beta: int = 1) -> None:
+    def __init__(self, ignore_nans: bool, beta: int = 1,
+                 spread_norm: float = None) -> None:
         super(CRPSLoss, self).__init__()
         self.ignore_nans = ignore_nans
         self.beta = beta
+        self.spread_norm = spread_norm
 
     def forward(self, target: torch.Tensor, output) -> torch.Tensor:
 
         if isinstance(output, torch.Tensor):
             output = [output]
-        
+
         if self.ignore_nans:
             nans_idx = torch.isnan(target)
             target = target[~nans_idx]
@@ -67,12 +74,18 @@ class CRPSLoss(nn.Module):
             for i in range(M):
                 for j in range(M):
                     second_term += torch.abs(output[i] - output[j]) ** self.beta
-            second_term = second_term / (2*M*(M-1)) # Fair CRPS
+            divisor = self.spread_norm if self.spread_norm is not None else 2*M*(M-1)
+            second_term = second_term / divisor
         else:
             second_term = 0.0
 
         # Final loss
         loss = torch.mean(first_term - second_term)
+
+        self.last_components = {
+            'accuracy': torch.mean(first_term).item(),
+            'spread': torch.mean(second_term).item() if M > 1 else 0.0,
+        }
 
         return loss
 
@@ -107,6 +120,11 @@ class CRPSSpectralLoss(nn.Module):
     lambda_spectral : float
         Weight for the spectral CRPS.
 
+    spread_norm : float, optional
+        Divisor for the spread term (second term) in both the pointwise and
+        spectral CRPS branches. When None (default), the fair-CRPS divisor
+        2*M*(M-1) is used. Pass a custom value (e.g. 2) to override it.
+
     spatial_resolution : float, optional
         Spatial resolution of the predictand grid in km. When provided, a
         low-pass filter is applied in the spectral CRPS branch to remove
@@ -123,9 +141,10 @@ class CRPSSpectralLoss(nn.Module):
     """
 
     def __init__(self, ignore_nans: bool,
-                 H_shape: int, W_shape: int, 
+                 H_shape: int, W_shape: int,
                  beta: int = 1,
                  lambda_spectral: float = 0.1,
+                 spread_norm: float = None,
                  spatial_resolution: float = None) -> None:
         super(CRPSSpectralLoss, self).__init__()
         self.ignore_nans = ignore_nans
@@ -133,12 +152,13 @@ class CRPSSpectralLoss(nn.Module):
         self.W_shape = W_shape
         self.beta = beta
         self.lambda_spectral = lambda_spectral
+        self.spread_norm = spread_norm
         if spatial_resolution is not None and spatial_resolution <= 0:
             raise ValueError("spatial_resolution must be > 0 when provided.")
         self.spatial_resolution = spatial_resolution
 
-    def _CRPS_pointwise(self, target: torch.Tensor,output,
-                        *, filter_nans: bool = False) -> torch.Tensor:
+    def _CRPS_pointwise(self, target: torch.Tensor, output,
+                        *, filter_nans: bool = False):
         if self.ignore_nans and filter_nans:
             nans_idx = torch.isnan(target)
             target = target[~nans_idx]
@@ -159,14 +179,18 @@ class CRPSSpectralLoss(nn.Module):
             for i in range(M):
                 for j in range(M):
                     second_term += torch.abs(output[i] - output[j]) ** self.beta
-            second_term = second_term / (2*M*(M-1)) # Fair CRPS
+            divisor = self.spread_norm if self.spread_norm is not None else 2*M*(M-1)
+            second_term = second_term / divisor
         else:
             second_term = 0.0
 
         # Final loss
         loss = torch.mean(first_term - second_term)
 
-        return loss
+        accuracy = torch.mean(first_term).item()
+        spread = torch.mean(second_term).item() if M > 1 else 0.0
+
+        return loss, accuracy, spread
 
     def _FFT(self, data: torch.Tensor) -> list[torch.Tensor]:
         # Fill nans with 0 for the FFT computation
@@ -205,13 +229,23 @@ class CRPSSpectralLoss(nn.Module):
             output = [output]
 
         # Compute standard CRPS (spectral branch does not filter nans; see _CRPS_pointwise)
-        crps_field = self._CRPS_pointwise(target, output, filter_nans=True)
+        crps_field, field_accuracy, field_spread = self._CRPS_pointwise(
+            target, output, filter_nans=True)
 
         # Compute spectral CRPS
         target_fft = self._FFT(target)[0]
         output_fft = self._FFT(output)
-        crps_spectral = self._CRPS_pointwise(target_fft, output_fft)
+        crps_spectral, spectral_accuracy, spectral_spread = self._CRPS_pointwise(
+            target_fft, output_fft)
 
         # Compute total loss
         loss = crps_field + self.lambda_spectral * crps_spectral
+
+        self.last_components = {
+            'field_accuracy': field_accuracy,
+            'field_spread': field_spread,
+            'spectral_accuracy': spectral_accuracy,
+            'spectral_spread': spectral_spread,
+        }
+
         return loss

--- a/deep4downscaling/deep/loss/crps.py
+++ b/deep4downscaling/deep/loss/crps.py
@@ -28,11 +28,6 @@ class CRPSLoss(nn.Module):
     beta : int
         Power parameter for the absolute differences in the CRPS computation.
 
-    spread_norm : float, optional
-        Divisor for the spread term (second term). When None (default), the
-        fair-CRPS divisor 2*M*(M-1) is used. Pass a custom value (e.g. 2)
-        to override it.
-
     target : torch.Tensor
         Target/ground-truth data
 
@@ -42,12 +37,10 @@ class CRPSLoss(nn.Module):
         For proper CRPS computation, at least 2 ensemble members are required.
     """
 
-    def __init__(self, ignore_nans: bool, beta: int = 1,
-                 spread_norm: float = None) -> None:
+    def __init__(self, ignore_nans: bool, beta: int = 1) -> None:
         super(CRPSLoss, self).__init__()
         self.ignore_nans = ignore_nans
         self.beta = beta
-        self.spread_norm = spread_norm
 
     def forward(self, target: torch.Tensor, output) -> torch.Tensor:
 
@@ -74,18 +67,16 @@ class CRPSLoss(nn.Module):
             for i in range(M):
                 for j in range(M):
                     second_term += torch.abs(output[i] - output[j]) ** self.beta
-            divisor = self.spread_norm if self.spread_norm is not None else 2*M*(M-1)
-            second_term = second_term / divisor
+            second_term = second_term / (2*M*(M-1)) # Fair CRPS
         else:
             second_term = 0.0
 
         # Final loss
         loss = torch.mean(first_term - second_term)
 
-        self.last_components = {
-            'accuracy': torch.mean(first_term).item(),
-            'spread': torch.mean(second_term).item() if M > 1 else 0.0,
-        }
+        # Store last components
+        self.last_components = {'accuracy': torch.mean(first_term).item(),
+                                'spread': torch.mean(second_term).item() if M > 1 else 0.0}
 
         return loss
 
@@ -120,11 +111,6 @@ class CRPSSpectralLoss(nn.Module):
     lambda_spectral : float
         Weight for the spectral CRPS.
 
-    spread_norm : float, optional
-        Divisor for the spread term (second term) in both the pointwise and
-        spectral CRPS branches. When None (default), the fair-CRPS divisor
-        2*M*(M-1) is used. Pass a custom value (e.g. 2) to override it.
-
     spatial_resolution : float, optional
         Spatial resolution of the predictand grid in km. When provided, a
         low-pass filter is applied in the spectral CRPS branch to remove
@@ -144,7 +130,6 @@ class CRPSSpectralLoss(nn.Module):
                  H_shape: int, W_shape: int,
                  beta: int = 1,
                  lambda_spectral: float = 0.1,
-                 spread_norm: float = None,
                  spatial_resolution: float = None) -> None:
         super(CRPSSpectralLoss, self).__init__()
         self.ignore_nans = ignore_nans
@@ -152,7 +137,6 @@ class CRPSSpectralLoss(nn.Module):
         self.W_shape = W_shape
         self.beta = beta
         self.lambda_spectral = lambda_spectral
-        self.spread_norm = spread_norm
         if spatial_resolution is not None and spatial_resolution <= 0:
             raise ValueError("spatial_resolution must be > 0 when provided.")
         self.spatial_resolution = spatial_resolution
@@ -179,8 +163,7 @@ class CRPSSpectralLoss(nn.Module):
             for i in range(M):
                 for j in range(M):
                     second_term += torch.abs(output[i] - output[j]) ** self.beta
-            divisor = self.spread_norm if self.spread_norm is not None else 2*M*(M-1)
-            second_term = second_term / divisor
+            second_term = second_term / (2*M*(M-1)) # Fair CRPS
         else:
             second_term = 0.0
 
@@ -241,11 +224,10 @@ class CRPSSpectralLoss(nn.Module):
         # Compute total loss
         loss = crps_field + self.lambda_spectral * crps_spectral
 
-        self.last_components = {
-            'field_accuracy': field_accuracy,
-            'field_spread': field_spread,
-            'spectral_accuracy': spectral_accuracy,
-            'spectral_spread': spectral_spread,
-        }
+        # Store last components
+        self.last_components = {'field_accuracy': field_accuracy,
+                                'field_spread': field_spread,
+                                'spectral_accuracy': spectral_accuracy,
+                                'spectral_spread': spectral_spread}
 
         return loss

--- a/deep4downscaling/deep/tracker.py
+++ b/deep4downscaling/deep/tracker.py
@@ -16,6 +16,13 @@ import torch
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator, FuncFormatter
 
+_SPECTRAL_COMPONENT_DEFS = [
+    ("Field accuracy",    "train_field_accuracy",    "valid_field_accuracy",    "#1f77b4"),
+    ("Field spread",      "train_field_spread",       "valid_field_spread",      "#d62728"),
+    ("Spectral accuracy", "train_spectral_accuracy",  "valid_spectral_accuracy", "#2ca02c"),
+    ("Spectral spread",   "train_spectral_spread",    "valid_spectral_spread",   "#ff7f0e"),
+]
+
 
 class TrainingTracker:
 
@@ -34,7 +41,7 @@ class TrainingTracker:
         generated (e.g., exp_20260508_171000).
 
     log_every : int, optional
-        Frequency (in epochs) to save artifacts. By default set to 1.
+        Frequency (in epochs) to save artifacts. By default set to 5.
 
     num_samples : int, optional
         Number of random samples to track predictions for. By default set
@@ -52,12 +59,21 @@ class TrainingTracker:
     flip_lr : bool, optional
         If True, flip the prediction maps left-to-right before plotting.
         By default False.
+
+    lambda_spectral : float, optional
+        Weighting factor for the spectral loss components. When provided,
+        spectral columns in component_data.csv are multiplied by this value
+        before plotting so all components are on the same scale. A
+        ``loss_components.png`` figure styled after the intercomparison
+        plotting convention is saved alongside the standard
+        ``component_curves.png``.
     """
 
     def __init__(self, experiment_dir: str, experiment_name: str=None,
-                 log_every: int=1, num_samples: int=4,
+                 log_every: int=5, num_samples: int=4,
                  spatial_mask: np.ndarray=None,
-                 flip_ud: bool=False, flip_lr: bool=False) -> None:
+                 flip_ud: bool=False, flip_lr: bool=False,
+                 lambda_spectral: float=None) -> None:
 
         self.experiment_dir = os.path.expanduser(experiment_dir)
         self.log_every = log_every
@@ -65,6 +81,7 @@ class TrainingTracker:
         self.spatial_mask = spatial_mask
         self.flip_ud = flip_ud
         self.flip_lr = flip_lr
+        self.lambda_spectral = lambda_spectral
 
         # Generate experiment name if not provided
         if experiment_name is None:
@@ -148,6 +165,125 @@ class TrainingTracker:
                 f.write('epoch,train_loss\n')
                 for i, tl in enumerate(train_loss):
                     f.write(f'{i+1},{tl}\n')
+
+    def _save_component_curves(self, train_components: dict,
+                               valid_components: dict=None) -> None:
+
+        """
+        Save per-component loss curves as a PNG and CSV. Each component gets
+        its own color; train and validation are distinguished by solid vs.
+        dashed lines.
+
+        Parameters
+        ----------
+        train_components : dict
+            Mapping from component name to list of training values per epoch.
+
+        valid_components : dict, optional
+            Mapping from component name to list of validation values per epoch.
+        """
+
+        if not train_components:
+            return
+
+        component_names = list(train_components.keys())
+        n_epochs = len(next(iter(train_components.values())))
+        epochs = np.arange(1, n_epochs + 1)
+
+        colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
+
+        fig, ax = plt.subplots(figsize=(10, 6))
+
+        for idx, name in enumerate(component_names):
+            color = colors[idx % len(colors)]
+            ax.plot(epochs, train_components[name], label=f'{name} (train)',
+                    color=color, linestyle='-', marker='o', markersize=4)
+            if valid_components is not None and name in valid_components and \
+                    len(valid_components[name]) > 0:
+                ax.plot(epochs, valid_components[name],
+                        label=f'{name} (valid)', color=color, linestyle='--',
+                        marker='o', markersize=4)
+
+        ax.set_xlabel('Epoch')
+        ax.set_ylabel('Loss component value')
+        ax.set_title('Loss Component Curves')
+        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+        ax.xaxis.set_major_formatter(FuncFormatter(lambda x, _: f'{int(round(x))}'))
+        ax.legend()
+        ax.grid(True, alpha=0.3)
+
+        fig.tight_layout()
+        fig.savefig(os.path.join(self.loss_dir, 'component_curves.png'), dpi=150)
+        plt.close(fig)
+
+        # Save CSV
+        has_valid = valid_components is not None and len(valid_components) > 0
+        csv_path = os.path.join(self.loss_dir, "component_data.csv")
+        with open(csv_path, 'w') as f:
+            train_cols = ','.join(f'train_{n}' for n in component_names)
+            if has_valid:
+                valid_cols = ','.join(f'valid_{n}' for n in component_names)
+                f.write(f'epoch,{train_cols},{valid_cols}\n')
+            else:
+                f.write(f'epoch,{train_cols}\n')
+            for i in range(n_epochs):
+                train_vals = ','.join(
+                    str(train_components[n][i]) for n in component_names)
+                if has_valid:
+                    valid_vals = ','.join(
+                        str(valid_components[n][i]) for n in component_names)
+                    f.write(f'{i+1},{train_vals},{valid_vals}\n')
+                else:
+                    f.write(f'{i+1},{train_vals}\n')
+
+        if self.lambda_spectral is not None:
+            self._save_spectral_loss_curves()
+
+    def _save_spectral_loss_curves(self) -> None:
+
+        """
+        Read component_data.csv, scale spectral columns by lambda_spectral,
+        and save a loss_components.png figure with the same style as the
+        intercomparison plot_run function.
+        """
+
+        import pandas as pd
+
+        csv_path = os.path.join(self.loss_dir, "component_data.csv")
+        df = pd.read_csv(csv_path)
+        lam = self.lambda_spectral
+
+        spectral_cols = [c for c in df.columns if "spectral" in c]
+        for col in spectral_cols:
+            df[col] = df[col] * lam
+
+        fig, ax = plt.subplots(figsize=(10, 6))
+
+        for label, train_col, valid_col, color in _SPECTRAL_COMPONENT_DEFS:
+            scaled_label = (f"{label} × λ={lam}"
+                            if "Spectral" in label else label)
+            if train_col in df.columns:
+                ax.plot(df["epoch"], df[train_col],
+                        label=f"{scaled_label} — train",
+                        color=color, linewidth=1.8)
+            if valid_col in df.columns:
+                ax.plot(df["epoch"], df[valid_col],
+                        label=f"{scaled_label} — valid",
+                        color=color, linewidth=1.8, linestyle="--")
+
+        ax.set_xlabel("Epoch", fontweight="bold")
+        ax.set_ylabel("Loss", fontweight="bold")
+        ax.set_title(
+            f"Loss components — {self.experiment_name}"
+            f"  (spectral × λ={lam})",
+            fontsize=13, fontweight="bold",
+        )
+        ax.legend(fontsize=9, ncol=2)
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+        fig.savefig(os.path.join(self.loss_dir, "loss_components.png"),
+                    dpi=150, bbox_inches="tight")
+        plt.close(fig)
 
     def _reshape_to_2d(self, arr: np.ndarray) -> np.ndarray:
 
@@ -296,6 +432,8 @@ class TrainingTracker:
 
     def log_epoch(self, epoch: int, train_loss: list,
                   valid_loss: list=None,
+                  train_loss_components: dict=None,
+                  valid_loss_components: dict=None,
                   model: torch.nn.Module=None,
                   train_data: torch.utils.data.DataLoader=None,
                   valid_data: torch.utils.data.DataLoader=None,
@@ -318,6 +456,14 @@ class TrainingTracker:
             List of validation loss values up to and including the current
             epoch.
 
+        train_loss_components : dict, optional
+            Mapping from component name to list of training values per epoch.
+            When provided, a component_curves.png plot is saved alongside the
+            main loss_curves.png.
+
+        valid_loss_components : dict, optional
+            Mapping from component name to list of validation values per epoch.
+
         model : torch.nn.Module, optional
             Model to use for generating prediction samples. If not provided,
             prediction samples are not saved.
@@ -338,6 +484,11 @@ class TrainingTracker:
 
         # Save loss curves
         self._save_loss_curves(train_loss, valid_loss)
+
+        # Save component curves if available
+        if train_loss_components:
+            self._save_component_curves(train_loss_components,
+                                        valid_loss_components)
 
         # Save prediction samples
         if model is not None:

--- a/deep4downscaling/deep/tracker.py
+++ b/deep4downscaling/deep/tracker.py
@@ -6,7 +6,9 @@ prediction samples at configurable intervals to the local filesystem.
 This module does not work with models trained using loss functions that do not
 return the variable to be predicted (e.g., BernoulliGammaLoss).
 
-Author: Jose González-Abad
+Authors:
+    Jose González-Abad
+    Carlota García Fernández
 """
 
 import os
@@ -16,12 +18,11 @@ import torch
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator, FuncFormatter
 
-_SPECTRAL_COMPONENT_DEFS = [
-    ("Field accuracy",    "train_field_accuracy",    "valid_field_accuracy",    "#1f77b4"),
-    ("Field spread",      "train_field_spread",       "valid_field_spread",      "#d62728"),
-    ("Spectral accuracy", "train_spectral_accuracy",  "valid_spectral_accuracy", "#2ca02c"),
-    ("Spectral spread",   "train_spectral_spread",    "valid_spectral_spread",   "#ff7f0e"),
-]
+# Define component definitions for spectral loss curves
+_SPECTRAL_COMPONENT_DEFS = [("Field accuracy",    "train_field_accuracy",    "valid_field_accuracy",    "#1f77b4"),
+                            ("Field spread",      "train_field_spread",       "valid_field_spread",      "#d62728"),
+                            ("Spectral accuracy", "train_spectral_accuracy",  "valid_spectral_accuracy", "#2ca02c"),
+                            ("Spectral spread",   "train_spectral_spread",    "valid_spectral_spread",   "#ff7f0e")]
 
 
 class TrainingTracker:

--- a/deep4downscaling/deep/train.py
+++ b/deep4downscaling/deep/train.py
@@ -24,6 +24,7 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
                            clip_gradients_norm: float=None,
                            save_checkpoint_every: int=None,
                            resume_checkpoint: str=None,
+                           save_versions_every: int=None,
                            tracker: 'TrainingTracker'=None) -> dict:
     
     """
@@ -97,6 +98,12 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
         training state (model, optimizer, scheduler, scaler, epoch and loss
         history).
 
+    save_versions_every : int, optional
+        Frequency (in epochs) to save a versioned copy of the model weights
+        into {model_path}/{model_name}_versions/. Each copy is named
+        {model_name}_epoch_{epoch}.pt. Only the model weights are saved (not
+        optimizer state). If None, no versioned copies are saved.
+
     tracker : TrainingTracker, optional
         Training tracker instance for logging during training. If not
         provided, no tracking is performed.
@@ -109,6 +116,10 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
     """
 
     model = model.to(device)
+
+    if save_versions_every is not None:
+        versions_dir = os.path.expanduser(f'{model_path}/{model_name}_versions')
+        os.makedirs(versions_dir, exist_ok=True)
 
     # The scaler scales the loss to avoid the underflow
     # of gradients
@@ -123,6 +134,8 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
     # Register the losses per epoch
     epoch_train_loss = []
     epoch_valid_loss = []
+    epoch_train_components = {}
+    epoch_valid_components = {}
 
     start_epoch = 0
 
@@ -139,6 +152,8 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
         start_epoch = checkpoint['epoch'] + 1
         epoch_train_loss = checkpoint.get('train_loss', [])
         epoch_valid_loss = checkpoint.get('valid_loss', [])
+        epoch_train_components = checkpoint.get('train_components', {})
+        epoch_valid_components = checkpoint.get('valid_components', {})
         if patience_early_stopping is not None:
             best_val_loss = checkpoint.get('best_val_loss', math.inf)
         print(f'Resumed from epoch {start_epoch}')
@@ -148,6 +163,7 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
         
         epoch_start = time.time()
         epoch_train_loss.append(0)
+        batch_train_components = {}
 
         # Iterate over batches
         model.train()
@@ -158,7 +174,7 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
 
             optimizer.zero_grad()
 
-            if mixed_precision: 
+            if mixed_precision:
                 with torch.amp.autocast(device_type=device):
                     output = model(x)
                     loss = loss_function(target=y, output=output)
@@ -171,39 +187,50 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
             else:
                 output = model(x)
                 loss = loss_function(target=y, output=output)
-                loss.backward()               
+                loss.backward()
                 if clip_gradients_norm is not None:
                     torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=clip_gradients_norm)
                 optimizer.step()
 
             epoch_train_loss[-1] += loss.item()
+            if hasattr(loss_function, 'last_components'):
+                for k, v in loss_function.last_components.items():
+                    batch_train_components[k] = batch_train_components.get(k, 0.0) + v
 
         # Compute mean loss across the epoch
         epoch_train_loss[-1] = epoch_train_loss[-1] / len(train_data)
+        for k, v in batch_train_components.items():
+            epoch_train_components.setdefault(k, []).append(v / len(train_data))
 
         # If valid data is provided, perform a pass through it
         if valid_data is not None:
 
             epoch_valid_loss.append(0)
+            batch_valid_components = {}
 
             model.eval()
             for x, y in valid_data:
 
                 x = x.to(device)
-                y = y.to(device)    
+                y = y.to(device)
 
-                if mixed_precision: 
+                if mixed_precision:
                     with torch.amp.autocast(device_type=device):
                         output = model(x)
                         loss = loss_function(target=y, output=output)
                 else:
-                        output = model(x)
-                        loss = loss_function(target=y, output=output)                    
+                    output = model(x)
+                    loss = loss_function(target=y, output=output)
 
                 epoch_valid_loss[-1] += loss.item()
+                if hasattr(loss_function, 'last_components'):
+                    for k, v in loss_function.last_components.items():
+                        batch_valid_components[k] = batch_valid_components.get(k, 0.0) + v
 
             # Compute mean loss across the epoch
             epoch_valid_loss[-1] = epoch_valid_loss[-1] / len(valid_data)
+            for k, v in batch_valid_components.items():
+                epoch_valid_components.setdefault(k, []).append(v / len(valid_data))
 
         epoch_end = time.time()
         epoch_time = np.round(epoch_end - epoch_start, 2)
@@ -261,17 +288,27 @@ def standard_training_loop(model: torch.nn.Module, model_name: str, model_path: 
                         'scaler': scaler.state_dict() if mixed_precision else None,
                         'best_val_loss': best_val_loss if patience_early_stopping is not None else None,
                         'train_loss': epoch_train_loss,
-                        'valid_loss': epoch_valid_loss}, ckpt_path)
+                        'valid_loss': epoch_valid_loss,
+                        'train_components': epoch_train_components,
+                        'valid_components': epoch_valid_components}, ckpt_path)
             log_msg = log_msg + ' (Checkpoint saved)'
+
+        # Save versioned copy of model weights
+        if save_versions_every is not None and (epoch + 1) % save_versions_every == 0:
+            version_path = os.path.join(versions_dir, f'{model_name}_epoch_{epoch + 1}.pt')
+            torch.save(model.state_dict(), version_path)
+            log_msg = log_msg + ' (Version saved)'
 
         # Log to tracker
         if tracker is not None and (epoch + 1) % tracker.log_every == 0:
             tracker.log_epoch(epoch=epoch, train_loss=epoch_train_loss,
                               valid_loss=epoch_valid_loss if valid_data is not None else None,
+                              train_loss_components=epoch_train_components or None,
+                              valid_loss_components=epoch_valid_components or None,
                               model=model, train_data=train_data,
                               valid_data=valid_data, device=device,
                               mixed_precision=mixed_precision)
-        
+
         # Print log
         print(log_msg)
 
@@ -410,6 +447,8 @@ def adversarial_training_loop(model: torch.nn.Module, model_name: str, model_pat
     # Register the losses per epoch
     epoch_train_loss = []
     epoch_valid_loss = []
+    epoch_train_components = {}
+    epoch_valid_components = {}
 
     start_epoch = 0
 
@@ -426,16 +465,19 @@ def adversarial_training_loop(model: torch.nn.Module, model_name: str, model_pat
         start_epoch = checkpoint['epoch'] + 1
         epoch_train_loss = checkpoint.get('train_loss', [])
         epoch_valid_loss = checkpoint.get('valid_loss', [])
+        epoch_train_components = checkpoint.get('train_components', {})
+        epoch_valid_components = checkpoint.get('valid_components', {})
         if patience_early_stopping is not None:
             best_val_loss = checkpoint.get('best_val_loss', math.inf)
         print(f'Resumed from epoch {start_epoch}')
-    
+
     # Iterate over epochs
     for epoch in range(start_epoch, num_epochs):
-        
+
         epoch_start = time.time()
         epoch_train_loss.append(0)
-        
+        batch_train_components = {}
+
         # Iterate over batches
         model.train()
         for x, y in train_data:
@@ -857,6 +899,11 @@ def standard_cgan_training_loop(generator: torch.nn.Module,
                 running_adv_loss.append(loss_adv.item())
                 running_recon_loss.append(loss_recon.item())
 
+            # Accumulate loss components (average of original and adversarial passes)
+            if hasattr(loss_function, 'last_components'):
+                for k, v in loss_function.last_components.items():
+                    batch_train_components[k] = batch_train_components.get(k, 0.0) + v
+
         # Compute mean epoch losses
         epoch_G_loss.append(float(np.mean(running_G_loss)))
         epoch_D_loss.append(float(np.mean(running_D_loss)))
@@ -864,11 +911,15 @@ def standard_cgan_training_loop(generator: torch.nn.Module,
         epoch_recon_loss.append(float(np.mean(running_recon_loss)))
         epoch_loss_D_real.append(float(np.mean(running_loss_D_real)))
         epoch_loss_D_fake.append(float(np.mean(running_loss_D_fake)))
+        n_gen_batches = max(len(running_G_loss), 1)
+        for k, v in batch_train_components.items():
+            epoch_train_components.setdefault(k, []).append(v / n_gen_batches)
 
         # Validation (reconstruction only)
         if valid_data is not None:
             generator.eval()
             val_loss = 0.0
+            batch_valid_components = {}
             with torch.no_grad():
                 for Xv, Yv in valid_data:
                     Xv, Yv = Xv.to(device), Yv.to(device)
@@ -879,8 +930,13 @@ def standard_cgan_training_loop(generator: torch.nn.Module,
                     else:
                         Y_pred = generator(Xv)
                         val_loss += recon_criterion(Yv, Y_pred).item()
+                    if hasattr(loss_function, 'last_components'):
+                        for k, v in loss_function.last_components.items():
+                            batch_valid_components[k] = batch_valid_components.get(k, 0.0) + v
             val_loss /= len(valid_data)
             epoch_val_loss.append(val_loss)
+            for k, v in batch_valid_components.items():
+                epoch_valid_components.setdefault(k, []).append(v / len(valid_data))
         else:
             val_loss = None
 
@@ -941,6 +997,8 @@ def standard_cgan_training_loop(generator: torch.nn.Module,
         if tracker is not None and (epoch + 1) % tracker.log_every == 0:
             tracker.log_epoch(epoch=epoch, train_loss=epoch_G_loss,
                               valid_loss=epoch_val_loss if valid_data is not None else None,
+                              train_loss_components=epoch_train_components or None,
+                              valid_loss_components=epoch_valid_components or None,
                               model=generator, train_data=train_data,
                               valid_data=valid_data, device=device,
                               mixed_precision=mixed_precision)

--- a/deep4downscaling/deep/train.py
+++ b/deep4downscaling/deep/train.py
@@ -4,6 +4,7 @@ This module contains the functions for training deep learning models.
 Authors:
     Jose González-Abad
     Alfonso Hernanz
+    Carlota García Fernández
 """
 
 import os
@@ -795,6 +796,8 @@ def standard_cgan_training_loop(generator: torch.nn.Module,
     epoch_G_loss, epoch_D_loss, epoch_val_loss = [], [], []
     epoch_adv_loss, epoch_recon_loss = [], []
     epoch_loss_D_real, epoch_loss_D_fake = [], []
+    epoch_train_components = {}
+    epoch_valid_components = {}
 
     # Resume from checkpoint if provided
     if resume_checkpoint is not None:
@@ -833,6 +836,7 @@ def standard_cgan_training_loop(generator: torch.nn.Module,
         running_G_loss, running_D_loss = [], []
         running_adv_loss, running_recon_loss = [], []
         running_loss_D_real, running_loss_D_fake = [], []
+        batch_train_components = {}
 
         for i, (X, Y_real) in enumerate(train_data):
             X, Y_real = X.to(device), Y_real.to(device)


### PR DESCRIPTION
`deep/train.py` — Versioned model snapshots
Added optional parameter save_versions_every: int = None to standard_training_loop. When set, the function creates a `{model_name}_versions/` subdirectory inside model_path and saves a copy of the model weights` ({model_name}_epoch_{N}.pt)` every save_versions_every epochs. The main model file that is overwritten each epoch is unaffected. The epoch number is appended to the log message as (Version saved).

`deep/loss/crps.py` — Configurable spread normalisation
Added optional parameter spread_norm: float = None to both CRPSLoss and CRPSSpectralLoss. When None (default), the fair-CRPS divisor `2*M*(M-1)` is used unchanged. When a value is provided, it replaces that divisor for the spread term, allowing experimentation with alternative normalisations.

`deep/tracker.py` — Spectral loss component figure
Added optional parameter lambda_spectral: float = None to TrainingTracker. When provided, after each component CSV update a loss_components.png figure is saved alongside the existing component_curves.png. The figure scales the spectral accuracy and spread columns by lambda_spectral so all four components (field accuracy, field spread, spectral accuracy × λ, spectral spread × λ) are plotted on the same scale, making it easier to monitor the relative contribution of the spectral branch during training.